### PR TITLE
Add installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Note: In Tensorflow 1.5 it is a known issue of TensorBoard not launching properl
 python -m tensorboard.main --logdir=mnist_TB_logs
 ```
 
+### Installation and running (with bash)
+
+To install all the dependencies and execute all supposed 
+routines run the following:
+```
+sh install_and_run.sh
+```
+
 ## Built With
 
 * [TensorFlow](https://www.tensorflow.org/) - Framework version 1.2.1 used

--- a/install_and_run.sh
+++ b/install_and_run.sh
@@ -1,0 +1,25 @@
+# Install modules for virtual environments
+# if they aren't installed now
+
+command -v mkvirtualenv >/dev/null 2>&1 || {
+sudo pip3 install virtualenv virtualenvwrapper
+echo'export WORKON_HOME=$HOME/.virtualenvs
+export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
+source /usr/local/bin/virtualenvwrapper.sh' >> ~/.bashrc
+}
+
+# Make virtual environment 
+# with required version of TF
+
+mkvirtualenv tf-1 -p python3
+sudo pip install tensorflow==1.15
+
+# Run main scripts
+
+python CNN_TB_MNIST_Example.py
+tensorboard --logdir mnist_TB_logs
+
+# deactivate the virtual environments
+
+deactivate
+


### PR DESCRIPTION
I had some trouble using the scripts because it requires TF with version 1.x.
In this request, I wrote a script to install the acceptable version of TF and then run it and view results. There are no steps anymore. Just a command:
```
sh install_and_run.sh
```
This script is written for bash and I don't know how it works in other shells.